### PR TITLE
Add timing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,7 @@ foamrun
 *.pos
 constant/polyMesh/
 processor*
+pimplefoam.log
+postProcessing/
 localruns/
+setup.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ foamrun
 *.pos
 constant/polyMesh/
 processor*
+localruns/

--- a/1.txt
+++ b/1.txt
@@ -20055,8 +20055,8 @@ Plane Surface(7) = {2};
 BooleanDifference{ Surface{5}; Delete;}{ Surface{6,7}; Delete;}
 Extrude {0, 0, 1} {Surface{1}; Surface{5}; Layers{1}; Recombine;}
 Physical Surface("Interface11") = {20};
-Physical Surface("Interface12") = {10};
-Physical Surface("ConcentratorF") = {11:18};
+Physical Surface("Interface12") = {14};
+Physical Surface("ConcentratorF") = {10:13,15:18};
 Physical Surface("InletP") = {6};
 Physical Surface("OutletP") = {9};
 Physical Surface("Wall1s") = {7};

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -3,6 +3,10 @@
 ## Should be run after Turbine.msh is created
 ## Should be run only in this directory
 
+## Store outputs in new folder in localruns
+FOLDER=localruns/run.`ls localruns/ | wc -l`
+mkdir -p $FOLDER
+echo "Start time:" `date` >> $FOLDER/timings.txt
 
 ## Delete older intermediate files (except Turbine.msh)
 rm -rf pimplefoam.log
@@ -10,6 +14,7 @@ rm -rf postProcessing
 rm -rf processor*
 rm -rf *.pos
 rm -rf constant/polyMesh
+echo "Finished removing old files:" `date` >> $FOLDER/timings.txt
 
 ## Get ready for OpenFOAM computation
 gmshToFoam ./Turbine.msh
@@ -18,6 +23,16 @@ renumberMesh -overwrite
 rm -rf 0
 cp -rf 0.orig 0
 decomposePar
+echo "Now ready for OpenFOAM computation:" `date` >> $FOLDER/timings.txt
 
 ## Run OpenFOAM computation
 mpirun -np 4 pimpleFoam -parallel | tee pimplefoam.log
+echo "Done with OpenFOAM computation:" `date` >> $FOLDER/timings.txt
+
+## Copy files to output folder
+cp postProcessing/forces/0/coefficient.dat $FOLDER/
+cp pimplefoam.log $FOLDER/
+cp system/controlDict $FOLDER/
+cp system/fvSchemes $FOLDER/
+cp system/fvSolution $FOLDER/
+echo "Done copying files:" `date` >> $FOLDER/timings.txt

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -6,7 +6,7 @@
 ## Store outputs in new folder in localruns
 FOLDER=localruns/run.`ls localruns/ | wc -l`
 mkdir -p $FOLDER
-echo "Start time:" `date` >> $FOLDER/timings.txt
+echo "Start time:                        " `date` >> $FOLDER/timings.txt
 
 ## Delete older intermediate files (except Turbine.msh)
 rm -rf pimplefoam.log
@@ -14,7 +14,7 @@ rm -rf postProcessing
 rm -rf processor*
 rm -rf *.pos
 rm -rf constant/polyMesh
-echo "Finished removing old files:" `date` >> $FOLDER/timings.txt
+echo "Finished removing old files:       " `date` >> $FOLDER/timings.txt
 
 ## Get ready for OpenFOAM computation
 gmshToFoam ./Turbine.msh
@@ -27,7 +27,7 @@ echo "Now ready for OpenFOAM computation:" `date` >> $FOLDER/timings.txt
 
 ## Run OpenFOAM computation
 mpirun -np 4 pimpleFoam -parallel | tee pimplefoam.log
-echo "Done with OpenFOAM computation:" `date` >> $FOLDER/timings.txt
+echo "Done with OpenFOAM computation:    " `date` >> $FOLDER/timings.txt
 
 ## Copy files to output folder
 cp postProcessing/forces/0/coefficient.dat $FOLDER/
@@ -35,4 +35,4 @@ cp pimplefoam.log $FOLDER/
 cp system/controlDict $FOLDER/
 cp system/fvSchemes $FOLDER/
 cp system/fvSolution $FOLDER/
-echo "Done copying files:" `date` >> $FOLDER/timings.txt
+echo "Done copying files:                " `date` >> $FOLDER/timings.txt

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -9,6 +9,7 @@ mkdir -p $FOLDER
 echo "Start time:                        " `date` >> $FOLDER/timings.txt
 
 ## Delete older intermediate files (except Turbine.msh)
+rm -rf setup.log
 rm -rf pimplefoam.log
 rm -rf postProcessing
 rm -rf processor*
@@ -17,12 +18,12 @@ rm -rf constant/polyMesh
 echo "Finished removing old files:       " `date` >> $FOLDER/timings.txt
 
 ## Get ready for OpenFOAM computation
-gmshToFoam ./Turbine.msh
-createPatch -overwrite
-renumberMesh -overwrite
+gmshToFoam ./Turbine.msh | tee -a setup.log
+createPatch -overwrite | tee -a setup.log
+renumberMesh -overwrite | tee -a setup.log
 rm -rf 0
 cp -rf 0.orig 0
-decomposePar
+decomposePar | tee -a setup.log
 echo "Now ready for OpenFOAM computation:" `date` >> $FOLDER/timings.txt
 
 ## Run OpenFOAM computation
@@ -35,4 +36,5 @@ cp pimplefoam.log $FOLDER/
 cp system/controlDict $FOLDER/
 cp system/fvSchemes $FOLDER/
 cp system/fvSolution $FOLDER/
+cp setup.log $FOLDER/
 echo "Done copying files:                " `date` >> $FOLDER/timings.txt

--- a/run_locally.sh
+++ b/run_locally.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+## Should be run after Turbine.msh is created
+## Should be run only in this directory
+
+
+## Delete older intermediate files (except Turbine.msh)
+rm -rf pimplefoam.log
+rm -rf postProcessing
+rm -rf processor*
+rm -rf *.pos
+rm -rf constant/polyMesh
+
+## Get ready for OpenFOAM computation
+gmshToFoam ./Turbine.msh
+createPatch -overwrite
+renumberMesh -overwrite
+rm -rf 0
+cp -rf 0.orig 0
+decomposePar
+
+## Run OpenFOAM computation
+mpirun -np 4 pimpleFoam -parallel | tee pimplefoam.log

--- a/system/controlDict
+++ b/system/controlDict
@@ -24,13 +24,13 @@ startTime       0;
 
 stopAt          endTime;
 
-endTime         10;
+endTime         0.005;
 
 deltaT          0.00005;
 
 writeControl    adjustableRunTime;
 
-writeInterval   0.05;
+writeInterval   0.0005;
 
 purgeWrite      4;
 
@@ -68,7 +68,7 @@ functions
     	pRef        0;
 	UName       U;
         rhoInf      1;
-	
+
  	CofR        (0 0 0);
 
         liftDir     (0 1 0);

--- a/system/decomposeParDict
+++ b/system/decomposeParDict
@@ -18,7 +18,7 @@ FoamFile
 
 preservePatches         (AMI1 AMI2);
 
-numberOfSubdomains 24;
+numberOfSubdomains 4;
 
 method          scotch;
 


### PR DESCRIPTION
The key difference is `run_locally.sh`. Now running that script will generate run printouts in the `localruns/` folder on your computer. I have adjusted the timings so each run takes about 10 minutes on my laptop.

I did a few tests already and noticed:
1. coefficient.dat and "No Iterations" is deterministic -- I ran it 3 times with endTime .005 and it was the same result each time.
2. running with a shorter endTime gave the same results as running with a longer endTime (at the same time).
3. writeInterval is a required field, but I don't think it's respected -- coefficient.dat gets a printout every deltaT, regardless of the value (I tried .0005 and .0001).

I can show you this in person also. It should now be much easier to compare run speeds with different OpenFOAM settings.